### PR TITLE
支持批量上传图片并添加上传结果页面

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -23,10 +23,9 @@
 <body>
   <div class="nav">
     <div>图片库后台</div>
-    <!-- 相对路径，避免跳到根域名 -->
     <div>
-      <a href=".." class="muted" style="margin-right:12px;text-decoration:none">首页</a>
-      <a href="admin/logout" class="muted" style="text-decoration:none">退出</a>
+      <a href="{{ url_for('index') }}" class="muted" style="margin-right:12px;text-decoration:none">首页</a>
+      <a href="{{ url_for('admin_logout') }}" class="muted" style="text-decoration:none">退出</a>
     </div>
   </div>
 
@@ -41,9 +40,8 @@
 
     <div class="card">
       <h2 style="margin-top:0">上传图片</h2>
-      <!-- 相对路径 / 或使用 url_for('admin_upload') -->
-      <form class="row" action="admin/upload" method="post" enctype="multipart/form-data">
-        <input type="file" name="file" accept="image/*" required />
+      <form class="row" action="{{ url_for('admin_upload') }}" method="post" enctype="multipart/form-data">
+        <input type="file" name="files" accept="image/*" required multiple />
         <input type="text" name="title" placeholder="标题（可选）" />
         <input type="date" name="date" />
         <button type="submit">上传</button>
@@ -58,18 +56,16 @@
         {% for r in rows %}
           <tr>
             <td>{{ r.id }}</td>
-            <td><img class="thumb" src="static/uploads/thumbs/{{ r.filename_thumb }}" alt=""></td>
+            <td><img class="thumb" src="{{ url_for('static', filename='uploads/thumbs/' ~ r.filename_thumb) }}" alt=""></td>
             <td>{{ r.title }}</td>
             <td>{{ r.date }}</td>
             <td>
-              <!-- 更新：相对路径 -->
-              <form class="inline" action="admin/update/{{ r.id }}" method="post">
+              <form class="inline" action="{{ url_for('admin_update', pid=r.id) }}" method="post">
                 <input type="text" name="title" placeholder="新标题" />
                 <input type="date" name="date" />
                 <button type="submit">更新</button>
               </form>
-              <!-- 删除：相对路径 -->
-              <form class="inline" action="admin/delete/{{ r.id }}" method="post"
+              <form class="inline" action="{{ url_for('admin_delete', pid=r.id) }}" method="post"
                     onsubmit="return confirm('确定删除？')">
                 <button type="submit" style="background:#ef4444">删除</button>
               </form>

--- a/templates/upload_success.html
+++ b/templates/upload_success.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>上传完成</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:0;background:#f6f7fb}
+    .wrap{max-width:700px;margin:40px auto;padding:0 16px}
+    .card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:20px;box-shadow:0 2px 6px rgba(0,0,0,.05)}
+    ul{padding-left:20px}
+    a.button{display:inline-block;margin-top:12px;padding:10px 14px;background:#2563eb;color:#fff;border-radius:10px;text-decoration:none}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <h1 style="margin-top:0">上传完成</h1>
+      {% if successes %}
+      <p>成功上传 {{ successes|length }} 张图片：</p>
+      <ul>
+        {% for name in successes %}
+        <li>{{ name }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% if errors %}
+      <p>以下文件上传失败：</p>
+      <ul>
+        {% for err in errors %}
+        <li>{{ err }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      <a class="button" href="{{ url_for('admin') }}">返回后台</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 支持同时上传多张图片并在完成后展示结果
- 管理后台表单支持多选上传
- 新增上传结果页面，列出成功或失败的文件并提供返回入口
- 修正后台所有跳转与链接的路径，避免出现 `/admin/admin` 等错误地址

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3cd5f5ecc8326a11ab2d61b09c43a